### PR TITLE
Fleshed out the autoMatchFields feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Options:
 | ------ | ------- | ----------- |
 | mapFields | N/A | (required) These are the field names that the CSV will be mapped to |
 | url | null | If present, the component will post the mapped values to this url.  Otherwise, the component will only emit the value to be used as a normal input |
+| autoMatchFields | false | If field names match csv headers, automatically match them |
+| autoMatchIgnoreCase | false | Ignore case when automatically matching fields (autoMatchFields required) |
 | callback  | null | The callback to be called on successful upload. (url required) |
 | catch | null | The function to be called on an error in posting (url required) |
 | finally | null | The function to be called no matter what on posting (url required) |

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Options:
 | ------ | ------- | ----------- |
 | mapFields | N/A | (required) These are the field names that the CSV will be mapped to |
 | url | null | If present, the component will post the mapped values to this url.  Otherwise, the component will only emit the value to be used as a normal input |
-| autoMatchFields | false | If field names match csv headers, automatically match them |
+| autoMatchFields | false | If field names match csv headers, automatically match them. Leading and trailing white space is trimmed before comparison. |
 | autoMatchIgnoreCase | false | Ignore case when automatically matching fields (autoMatchFields required) |
 | callback  | null | The callback to be called on successful upload. (url required) |
 | catch | null | The function to be called on an error in posting (url required) |

--- a/src/components/VueCsvImport.vue
+++ b/src/components/VueCsvImport.vue
@@ -280,11 +280,11 @@
                         this.fieldsToMap.forEach(field => {
                             newVal[0].forEach((columnName, index) => {
                                 if(this.autoMatchIgnoreCase === true){
-                                    if(field.key.toLowerCase() === columnName.toLowerCase()){
+                                    if(field.key.toLowerCase().trim() === columnName.toLowerCase().trim()){
                                         this.map[field.key] = index;
                                     }
                                 } else{
-                                    if(field.key === columnName){
+                                    if(field.key.trim() === columnName.trim()){
                                         this.map[field.key] = index;
                                     }
                                 }

--- a/src/components/VueCsvImport.vue
+++ b/src/components/VueCsvImport.vue
@@ -103,6 +103,14 @@
                 type: String,
                 default: "Submit"
             },
+            autoMatchFields: {
+                type: Boolean,
+                default: false
+            },
+            autoMatchIgnoreCase: {
+                type: Boolean,
+                default: false
+            },
             tableClass: {
                 type: String,
                 default: "table"
@@ -258,14 +266,22 @@
                 }
             },
             sample(newVal, oldVal) {
-                if(newVal !== null){
-                    this.fieldsToMap.forEach(field => {
-                        newVal[0].forEach((columnName, index) => {
-                            if(field.key === columnName){
-                                this.map[field.key] = index;
-                            }
+                if(this.autoMatchFields){
+                    if(newVal !== null){
+                        this.fieldsToMap.forEach(field => {
+                            newVal[0].forEach((columnName, index) => {
+                                if(this.autoMatchIgnoreCase === true){
+                                    if(field.key.toLowerCase() === columnName.toLowerCase()){
+                                        this.map[field.key] = index;
+                                    }
+                                } else{
+                                    if(field.key === columnName){
+                                        this.map[field.key] = index;
+                                    }
+                                }
+                            });
                         });
-                    });
+                    }
                 }
             }
         },

--- a/src/components/VueCsvImport.vue
+++ b/src/components/VueCsvImport.vue
@@ -280,11 +280,11 @@
                         this.fieldsToMap.forEach(field => {
                             newVal[0].forEach((columnName, index) => {
                                 if(this.autoMatchIgnoreCase === true){
-                                    if(field.key.toLowerCase().trim() === columnName.toLowerCase().trim()){
+                                    if(field.label.toLowerCase().trim() === columnName.toLowerCase().trim()){
                                         this.map[field.key] = index;
                                     }
                                 } else{
-                                    if(field.key.trim() === columnName.trim()){
+                                    if(field.label.trim() === columnName.trim()){
                                         this.map[field.key] = index;
                                     }
                                 }

--- a/tests/unit/vueCsvImport.spec.js
+++ b/tests/unit/vueCsvImport.spec.js
@@ -7,7 +7,9 @@ describe('VueCsvImport', () => {
     const localVue = createLocalVue();
     const csv = [["name", "age", "grade"], ["Susan", "41", "a"], ["Mike", "5", "b"], ["Jake", "33", "c"], ["Jill", "30", "d"]];
     const sample = [["name", "age", "grade"], ["Susan", "41", "a"]];
+    const sampleCapitalized = [["Name", "Age", "Grade"], ["Susan", "41", "a"]];
     const map = { "name": 0, "age": 1 };
+    const fields = [{ key: "name", label: "name" }, { key: "age", label: "age" }]
 
     beforeEach(() => {
         wrapper = shallowMount(VueCsvImport, { propsData: { mapFields: ['name_map', 'age_map', 'grade_map'], url: '/hello' } });
@@ -73,4 +75,15 @@ describe('VueCsvImport', () => {
         expect(wrapper.vm.validateMimeType('application/vnd.ms-excel')).toEqual(true);
         expect(wrapper.vm.validateMimeType('text/plain')).toEqual(true);
     });
+
+    it('automatically maps fields when cases match', async () => {
+        objWrapper.setProps({ autoMatchFields: true })
+        objWrapper.setData({ hasHeaders: true, sample: sampleCapitalized, csv: csv, fieldsToMap: fields });
+        expect(objWrapper.vm.map).toEqual({"age": 1, "name": 0});
+    })
+    it('automatically maps fields when cases do not match', async () => {
+        objWrapper.setProps({ autoMatchFields: true, autoMatchIgnoreCase: true })
+        objWrapper.setData({ hasHeaders: true, sample: sample, csv: csv, fieldsToMap: fields });
+        expect(objWrapper.vm.map).toEqual({"age": 1, "name": 0});
+    })
 });


### PR DESCRIPTION
This pr does four things:
- adds the ability for autoMatchFields to ignore the cases of field names and csv headers when matching.
- adds props to toggle these two features on/off called autoMatchFields and autoMatchIgnoreCase.
- adds documentation for autoMatchFields and autoMatchIgnoreCase to the readme
- autoMatchFields will ignore leading and trailing white space when doing comparisons.