### PR TITLE
ignoreOptionText + Post this.form.csv + Watch hasHeaders + Separated hasAllKeys callback from submit 

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Options:
 | headers | null | Define whether csv has headers by default.  Removes checkbox. |
 | fileMimeTypes | ["text/csv"] | Array of valid mime types
 | canIgnore | false | Can fields be ignored (Boolean)
+| ignoreOptionText | "Ignore" | The value of the ignore option in element selects
 
 Slots:
 

--- a/src/components/VueCsvImport.vue
+++ b/src/components/VueCsvImport.vue
@@ -75,9 +75,6 @@
             mapFields: {
                 required: true
             },
-            mapFieldsNames: {
-                required: false
-            },
             callback: {
                 type: Function,
                 default: () => ({})

--- a/src/components/VueCsvImport.vue
+++ b/src/components/VueCsvImport.vue
@@ -11,7 +11,7 @@
                     </slot>
                 </div>
                 <div class="form-group csv-import-file">
-                    <input ref="csv" type="file" @change.prevent="validFileMimeType" :class="inputClass" name="csv">
+                    <input ref="csv" type="file" @change.prevent="validFileMimeType" :class="inputClass" name="csv" :accept="fileMimeTypes">
                     <slot name="error" v-if="showErrorMessage">
                         <div class="invalid-feedback d-block">
                             File type is invalid
@@ -195,7 +195,7 @@
             saveMappedCSVtoJson() {
                 const _this = this;
                 this.form.csv = this.buildMappedCsv();
-                this.$emit('input', this.form.csv);
+                this.$emit('input', this.form.csv); //return value from component
                 _this.callback(this.form.csv);
             },
             buildMappedCsv() {

--- a/src/components/VueCsvImport.vue
+++ b/src/components/VueCsvImport.vue
@@ -127,7 +127,7 @@
             fileMimeTypes: {
                 type: Array,
                 default: () => {
-                    return ["text/csv", "text/x-csv", "application/vnd.ms-excel", "text/plain"];
+                    return ["text/csv", "text/x-csv", "text/plain"];
                 }
             },
             tableSelectClass: {


### PR DESCRIPTION
- Added `ignoreOptionText` 
- Post to url` this.form.csv` only
- Separated `hasAllKeys` callback from submit to preview Json before submitting to server
- Watch `hasHeaders` to correct json import on the fly without the need to reload `.csv` file
- Get rid of `"application/vnd.ms-excel"` mime [#30](https://github.com/jgile/vue-csv-import/issues/30) 