### PR TITLE
Fixed bug with automatchfields where a perfectly matched csv would not trigger the map watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Slots:
 ### Testing
 
 ```bash
-npm run test
+npm run test:unit
 ```
 
 ### Changelog

--- a/src/components/VueCsvImport.vue
+++ b/src/components/VueCsvImport.vue
@@ -261,7 +261,6 @@
             map: {
                 deep: true,
                 handler: function (newVal) {
-                    console.log("firing map")
                     if (!this.url) {
                         let hasAllKeys = Array.isArray(this.mapFields) ? every(this.mapFields, function (item) {
                             return newVal.hasOwnProperty(item);

--- a/src/components/VueCsvImport.vue
+++ b/src/components/VueCsvImport.vue
@@ -261,6 +261,7 @@
             map: {
                 deep: true,
                 handler: function (newVal) {
+                    console.log("firing map")
                     if (!this.url) {
                         let hasAllKeys = Array.isArray(this.mapFields) ? every(this.mapFields, function (item) {
                             return newVal.hasOwnProperty(item);
@@ -281,11 +282,11 @@
                             newVal[0].forEach((columnName, index) => {
                                 if(this.autoMatchIgnoreCase === true){
                                     if(field.label.toLowerCase().trim() === columnName.toLowerCase().trim()){
-                                        this.map[field.key] = index;
+                                        this.$set(this.map, field.key, index);
                                     }
                                 } else{
                                     if(field.label.trim() === columnName.trim()){
-                                        this.map[field.key] = index;
+                                        this.$set(this.map, field.key, index);
                                     }
                                 }
                             });

--- a/tests/unit/vueCsvImport.spec.js
+++ b/tests/unit/vueCsvImport.spec.js
@@ -79,18 +79,19 @@ describe('VueCsvImport', () => {
     it('automatically maps fields when cases match', async () => {
         objWrapper.setProps({ autoMatchFields: true })
         objWrapper.setData({ hasHeaders: true, sample: sampleCapitalized, csv: csv, fieldsToMap: fields });
-        expect(objWrapper.vm.map).toEqual({"age": 1, "name": 0});
-    })
+        expect(objWrapper.vm.map).toEqual({ "age": 1, "name": 0 });
+    });
 
     it('automatically maps fields when cases do not match', async () => {
         objWrapper.setProps({ autoMatchFields: true, autoMatchIgnoreCase: true })
         objWrapper.setData({ hasHeaders: true, sample: sample, csv: csv, fieldsToMap: fields });
-        expect(objWrapper.vm.map).toEqual({"age": 1, "name": 0});
-    })
+        expect(objWrapper.vm.map).toEqual({ "age": 1, "name": 0 });
+    });
+
     it('automatically maps fields when cases match', async () => {
         objWrapper.setProps({ autoMatchFields: true })
         objWrapper.setData({ hasHeaders: true, sample: sampleCapitalized, csv: csv, fieldsToMap: fields });
         expect(objWrapper.vm.form.csv).not.toEqual(null);
-    })
+    });
 
 });

--- a/tests/unit/vueCsvImport.spec.js
+++ b/tests/unit/vueCsvImport.spec.js
@@ -81,9 +81,16 @@ describe('VueCsvImport', () => {
         objWrapper.setData({ hasHeaders: true, sample: sampleCapitalized, csv: csv, fieldsToMap: fields });
         expect(objWrapper.vm.map).toEqual({"age": 1, "name": 0});
     })
+
     it('automatically maps fields when cases do not match', async () => {
         objWrapper.setProps({ autoMatchFields: true, autoMatchIgnoreCase: true })
         objWrapper.setData({ hasHeaders: true, sample: sample, csv: csv, fieldsToMap: fields });
         expect(objWrapper.vm.map).toEqual({"age": 1, "name": 0});
     })
+    it('automatically maps fields when cases match', async () => {
+        objWrapper.setProps({ autoMatchFields: true })
+        objWrapper.setData({ hasHeaders: true, sample: sampleCapitalized, csv: csv, fieldsToMap: fields });
+        expect(objWrapper.vm.form.csv).not.toEqual(null);
+    })
+
 });


### PR DESCRIPTION
This fixed the bug reported by @glenn-domin where a perfectly matching csv does not populate the form csv data object. This was because the sample watcher was changing the map object without maintaining reactivity. Solution was to switch from = to this.$set.

- Adds test to make sure form csv data object is getting populated
- Small formatting change to latest tests to coincide with older tests
- Fixed watcher code to update this.map with this.$set to maintain reactivity.
- Update readme with the correct test command