### PR TITLE
Make mapFields prop reactive by setting a watcher

### DIFF
--- a/src/components/VueCsvImport.vue
+++ b/src/components/VueCsvImport.vue
@@ -179,26 +179,29 @@ export default {
     }),
 
     created() {
-        this.hasHeaders = this.headers;
-
-        if (isArray(this.mapFields)) {
-            this.fieldsToMap = map(this.mapFields, (item) => {
-                return {
-                    key: item,
-                    label: item,
-                };
-            });
-        } else {
-            this.fieldsToMap = map(this.mapFields, (label, key) => {
-                return {
-                    key: key,
-                    label: label,
-                };
-            });
-        }
+        this.initializeFromProps();
     },
 
     methods: {
+        initializeFromProps() {
+            this.hasHeaders = this.headers;
+
+            if (isArray(this.mapFields)) {
+                this.fieldsToMap = map(this.mapFields, (item) => {
+                    return {
+                        key: item,
+                        label: item,
+                    };
+                });
+            } else {
+                this.fieldsToMap = map(this.mapFields, (label, key) => {
+                    return {
+                        key: key,
+                        label: label,
+                    };
+                });
+            }
+        },
         submit() {
             const _this = this;
             this.form.csv = this.buildMappedCsv();
@@ -316,6 +319,9 @@ export default {
                 }
             }
         },
+        mapFields() {
+            this.initializeFromProps();
+        }
     },
     computed: {
         firstRow() {


### PR DESCRIPTION
I'd like to be able to dynamically update the number (and names) of `map-fields` in my user interface after the VueCsvImport component has rendered.  Before this PR, VueCsvImport only looked at the prop values on creation (1st render), so one can not update props and have the new values propagate to the components (the props are not-reactive).  In this PR, I added a watcher to watch for changes to the `map-fields` prop and update internal data values of the VueCsvImport component (making the `map-fields` prop reactive.