### PR TITLE
New Mapping Component (Using Table Headers)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -18,7 +18,7 @@
     &lt;vue-csv-toggle-headers&gt;&lt;/vue-csv-toggle-headers&gt;
     &lt;vue-csv-errors&gt;&lt;/vue-csv-errors&gt;
     &lt;vue-csv-input&gt;&lt;/vue-csv-input&gt;
-    &lt;vue-csv-map :auto-match="false"&gt;&lt;/vue-csv-map&gt;
+    &lt;vue-csv-table-map :auto-match="false"&gt;&lt;/vue-csv-table-map&gt;
 &lt;/vue-csv-import&gt;</code></pre>
                     </div>
                 </div>
@@ -33,7 +33,7 @@
                             <vue-csv-errors></vue-csv-errors>
                             <vue-csv-toggle-headers></vue-csv-toggle-headers>
                             <vue-csv-input></vue-csv-input>
-                            <vue-csv-map :auto-match="false"></vue-csv-map>
+                            <vue-csv-table-map :auto-match="false" :table-attributes="{id: 'csv-table'}"></vue-csv-table-map>
                             <vue-csv-submit url="/"></vue-csv-submit>
                         </vue-csv-import>
                         <pre class="mt-15" v-if="csv"><code>{{ csv }}</code></pre>

--- a/src/components/VueCsvImport.vue
+++ b/src/components/VueCsvImport.vue
@@ -25,7 +25,9 @@
         toggleHeaders: 'File has headers',
         submitBtn: 'Submit',
         fieldColumn: 'Field',
-        csvColumn: 'Column'
+        csvColumn: 'Column',
+        requiredField: '*',
+        excludeField: 'Exclude field'
     };
 
     const mapFields = function (fields) {

--- a/src/components/VueCsvInput.vue
+++ b/src/components/VueCsvInput.vue
@@ -85,7 +85,7 @@
                 reader.readAsText(VueCsvImportData.file, "UTF-8");
                 reader.onload = function (evt) {
                     VueCsvImportData.csvSample = get(Papa.parse(evt.target.result, merge({
-                        preview: 2,
+                        preview: 10,
                         skipEmptyLines: true
                     }, props.parseConfig)), "data");
                     VueCsvImportData.rawCsv = get(Papa.parse(evt.target.result, merge({skipEmptyLines: true}, props.parseConfig)), "data");

--- a/src/components/VueCsvTableMap.vue
+++ b/src/components/VueCsvTableMap.vue
@@ -1,0 +1,131 @@
+<template>
+    <slot
+        :sample="VueCsvImportData.firstSampleRow"
+        :map="VueCsvImportData.map"
+        :fields="VueCsvImportData.fields"
+    >
+        <template v-if="VueCsvImportData.firstSampleRow">
+            <table v-bind="tableAttributes">
+              <thead>
+                <tr>
+                  <td v-for="(field, key) in headers" :key="field">
+                    {{ field }}
+                    <select
+                      v-model="csvMap[key]"
+                      :name="`csv_uploader_map_${key}`"
+                      required
+                    >
+                    <option value>{{ labels.excludeField }}</option>
+                      <option
+                          v-for="option in availableFields"
+                          :value="option.label" :key="option.key"
+                          :disabled="option.selected"
+                      >
+                            {{ option.label }}{{ option.required ? labels.requiredField : ''}}
+                      </option>
+                      <option
+                          v-if="!VueCsvImportData.fields.map(f => f.label).includes(field)"
+                          :value="field"
+                          :key="field"
+                      >
+                            {{ field }}
+                      </option>
+                    </select>
+                  </td>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="row in csvSample">
+                  <td v-for="item in row">{{item}}</td>
+                </tr>
+              </tbody>
+            </table>
+        </template>
+    </slot>
+</template>
+
+<script>
+    import {computed, inject, watch, reactive} from 'vue';
+
+    export default {
+        name: "CsvTableMap",
+        props: {
+            tableAttributes: {
+                type: Object,
+                default() {
+                    return {};
+                }
+            },
+            autoMatch: {
+                type: Boolean,
+                default: true
+            },
+            autoMatchIgnoreCase: {
+                type: Boolean,
+                default: true
+            }
+        },
+        setup(props) {
+            const VueCsvImportData = inject('VueCsvImportData');
+            const buildMappedCsv = inject('buildMappedCsv');
+            const labels = VueCsvImportData.language;
+            const csvMap = reactive({})
+
+            const availableFields = computed(() => {
+                return VueCsvImportData.fields.map((f) => {
+                    f.selected = Object.values(csvMap).includes(f.label)
+                    return f
+                })
+            })
+
+            watch(() => csvMap, function () {
+                VueCsvImportData.map = {}
+                for (const [key, value] of Object.entries(csvMap)) {
+                    if (value === "") { continue; }
+                    VueCsvImportData.map[value.toLowerCase()] = key;
+                }
+
+                if (VueCsvImportData.allFieldsAreMapped) {
+                    buildMappedCsv();
+                }
+            }, {deep: true});
+
+            const csvSample = computed(() => {
+                return VueCsvImportData.fileHasHeaders ? VueCsvImportData.csvSample : VueCsvImportData.csvSample.slice(1)
+            })
+
+            const headers = computed(() => {
+                if (VueCsvImportData.fileHasHeaders) {
+                    return [...Array(VueCsvImportData.firstSampleRow.length).keys()].map(i => `${labels.csvColumn} ${i}`)
+                } else {
+                    return VueCsvImportData.firstSampleRow
+                }
+            })
+
+            if (props.autoMatch) {
+                watch(() => VueCsvImportData.csvSample, function (newVal) {
+                    if (newVal) {
+                        VueCsvImportData.fields.forEach(field => {
+                            newVal[0].forEach((columnName, index) => {
+                                let fieldName = props.autoMatchIgnoreCase ? field.label.toLowerCase().trim() : field.label.trim();
+                                let colName = props.autoMatchIgnoreCase ? columnName.toLowerCase().trim() : columnName.trim();
+                                if (fieldName === colName) {
+                                    csvMap[index] = field.label;
+                                }
+                            });
+                        });
+                    }
+                });
+            }
+
+            return {
+                availableFields,
+                csvMap,
+                csvSample,
+                headers,
+                VueCsvImportData,
+                labels
+            }
+        }
+    };
+</script>

--- a/src/index.css
+++ b/src/index.css
@@ -6,3 +6,25 @@
   color: #2c3e50;
   margin-top: 60px;
 }
+#csv-table {
+  font-family: Arial, Helvetica, sans-serif;
+  border-collapse: collapse;
+  width: 100%;
+}
+
+#csv-table td, #csv-table th {
+  border: 1px solid #ddd;
+  padding: 8px;
+}
+
+#csv-table tr:nth-child(even){background-color: #f2f2f2;}
+
+#csv-table tr:hover {background-color: #ddd;}
+
+#csv-table th {
+  padding-top: 12px;
+  padding-bottom: 12px;
+  text-align: left;
+  background-color: #4CAF50;
+  color: white;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import VueCsvImport from "./components/VueCsvImport.vue";
 import VueCsvErrors from "./components/VueCsvErrors.vue";
 import VueCsvInput from "./components/VueCsvInput.vue";
 import VueCsvMap from "./components/VueCsvMap.vue";
+import VueCsvTableMap from "./components/VueCsvTableMap.vue";
 import VueCsvSubmit from "./components/VueCsvSubmit.vue";
 import VueCsvToggleHeaders from "./components/VueCsvToggleHeaders.vue";
 
@@ -14,6 +15,7 @@ const VueCsvImportPlugin = {
                 'vue-csv-errors': 'vue-csv-errors',
                 'vue-csv-input': 'vue-csv-input',
                 'vue-csv-map': 'vue-csv-map',
+                'vue-csv-table-map': 'vue-csv-table-map',
                 'vue-csv-submit': 'vue-csv-submit',
                 'vue-csv-toggle-headers': 'vue-csv-toggle-headers',
             }
@@ -23,9 +25,10 @@ const VueCsvImportPlugin = {
         app.component(options.components['vue-csv-errors'], VueCsvErrors)
         app.component(options.components['vue-csv-input'], VueCsvInput)
         app.component(options.components['vue-csv-map'], VueCsvMap)
+        app.component(options.components['vue-csv-table-map'], VueCsvTableMap)
         app.component(options.components['vue-csv-submit'], VueCsvSubmit)
         app.component(options.components['vue-csv-toggle-headers'], VueCsvToggleHeaders)
     }
 }
 
-export {VueCsvToggleHeaders, VueCsvSubmit, VueCsvMap, VueCsvInput, VueCsvErrors, VueCsvImport, VueCsvImportPlugin};
+export {VueCsvToggleHeaders, VueCsvSubmit, VueCsvMap, VueCsvTableMap, VueCsvInput, VueCsvErrors, VueCsvImport, VueCsvImportPlugin};


### PR DESCRIPTION
#  A new way to map the headers of the CSV.
I created a new component <vue-csv-table-map> that allows inverse mapping of the fields to column names.

## Feature Summary
- Show preview of data as a table once loaded
- List headers of csv with dropdowns to select a mapping from required fields passed from config
- Update how headers are mapped to rows (Inverse mapping back to  original before building the csvJson)
- Allow non-defined fields to be added to payload by includeing their name as an option
- By default, unselcted fields are not added to the json, then need to be explicitly include.
- Added some light styles to the demo table however it is blank by default.


## Screenies
![Record_select-area_20210526181804](https://user-images.githubusercontent.com/18641066/119696371-64eed680-be4f-11eb-9fc0-0fdcb187ce10.gif)

### Further Comments
- I've discovered a bug that if a csv map was previously valid then an invalid setting is created, the data is not updated and thus old values are still there, I believe this is happening in the current mapping too. (let me know if this is worth raising a ticket for)
- This also solves #66 as It allows adding unspecified fields to the json.

I really enjoyed working on this codebase, this was actually my first vue3 implementation, thanks for all the fun and learning! 

