### PR TITLE
allow encoding selection through Papaparse config

### DIFF
--- a/src/components/VueCsvInput.vue
+++ b/src/components/VueCsvInput.vue
@@ -82,7 +82,7 @@
                     VueCsvImportData.rawCsv.value = null;
                 }
                 let reader = new FileReader();
-                reader.readAsText(VueCsvImportData.file, "UTF-8");
+                reader.readAsText(VueCsvImportData.file, props.parseConfig.encoding || "UTF-8");
                 reader.onload = function (evt) {
                     VueCsvImportData.csvSample = get(Papa.parse(evt.target.result, merge({
                         preview: 2,


### PR DESCRIPTION
Papaparse offers an encoding option intside the parsing config to select the file encoding when parsing a local file.
However, this is ignored in vue-csv-import since vue-csv-import parses the text first, then offers it to papaparse later.

This makes it so the encoding of the file is ignored when passing a parse config through the parseConfig prop.

By checking if the parseConfig contains an encoding, and otherwise defaulting to UTF-8 we restore original behaviour with minimal change.