### PR TITLE
Fix Emit Errors On Submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,14 @@ Or use slot for custom markup:
 | submit        | Submit the CSV (POST) |
 | mappedCsv     | The mapped CSV object |
 
+#### Events:
+
+| Event         | Description |
+| ------------- | ----------- |
+| send-success  | Emitted upon success response from submission         |
+| send-error    | Emitted if error response is received from submission |
+| send-complete | Emitted after completion of submission promise        |
+
 ---
 
 ### VueCsvErrors

--- a/src/components/VueCsvSubmit.vue
+++ b/src/components/VueCsvSubmit.vue
@@ -23,7 +23,7 @@ export default {
             default: {}
         }
     },
-    setup(props) {
+    setup(props, context) {
         const VueCsvImportData = inject('VueCsvImportData');
         const buildMappedCsv = inject('buildMappedCsv');
         const labels = VueCsvImportData.language;
@@ -32,11 +32,11 @@ export default {
             buildMappedCsv();
 
             axios.post(props.url, {[VueCsvImportData.inputName]: VueCsvImportData.value}, props.config).then(response => {
-                emit('send-success', response);
+                context.emit('send-success', response);
             }).catch(response => {
-                emit('send-error', response);
+                context.emit('send-error', response);
             }).finally(response => {
-                emit('send-complete', response);
+                context.emit('send-complete', response);
             });
         };
 


### PR DESCRIPTION
This fixes the issue of `emit is not defined` when the csv is submitted. It also adds the events from CSV submission to the readme for ease of access.